### PR TITLE
Added capability to customise colours for plots

### DIFF
--- a/R/fancyMask.R
+++ b/R/fancyMask.R
@@ -28,6 +28,9 @@
 #'   `geom_mark_shape()`. Default is `"plain"`.
 #' @param label.margin Label margin passed to
 #'   `geom_mark_shape()`. Default is `margin(2, 2, 2, 2, "pt")`.
+#' @param cols Optional vector of colors for the mask outlines and labels.
+#'   Should have length equal to the number of unique clusters in `maskTable`.
+#'   If `NULL` (default), colors are generated automatically using `scales::hue_pal()`.
 #'
 #' @return A list of ggplot2 components suitable for adding to a plot with `+`,
 #'   containing:
@@ -64,7 +67,8 @@ fancyMask <- function(maskTable,
                       label.fontsize = 10,
                       label.buffer = unit(0, "cm"),
                       label.fontface = "plain",
-                      label.margin = margin(2, 2, 2, 2, "pt")
+                      label.margin = margin(2, 2, 2, 2, "pt"),
+                      cols = NULL
                       ) {
     xvar <- colnames(maskTable)[1]
     yvar <- colnames(maskTable)[2]
@@ -75,11 +79,20 @@ fancyMask <- function(maskTable,
     xyWidths <- apply(xyRanges, 2, diff)
     xyRanges <- xyRanges + c(-1, 1)  %*% t(xyWidths * limits.expand)
 
-    # TODO: make colors controllable
-    colors <- NULL
+    # Set colors for mask outlines and labels
+    colors <- cols
     if (is.null(colors)) {
         clusterLevels <- levels(maskTable$cluster)
         pal <- setNames(scales::hue_pal()(length(clusterLevels)), clusterLevels)
+        colors <- pal[maskTable$cluster]
+    } else {
+        # Map provided colors to clusters
+        clusterLevels <- levels(maskTable$cluster)
+        if (length(colors) != length(clusterLevels)) {
+            warning("Length of 'cols' (", length(colors), ") does not match number of clusters (", 
+                   length(clusterLevels), "). Colors will be recycled or truncated.")
+        }
+        pal <- setNames(rep(colors, length.out = length(clusterLevels)), clusterLevels)
         colors <- pal[maskTable$cluster]
     }
 

--- a/R/fancyMask.R
+++ b/R/fancyMask.R
@@ -88,10 +88,11 @@ fancyMask <- function(maskTable,
     } else {
         # Map provided colors to clusters
         clusterLevels <- levels(maskTable$cluster)
-        if (length(colors) != length(clusterLevels)) {
-            warning("Length of 'cols' (", length(colors), ") does not match number of clusters (", 
-                   length(clusterLevels), "). Colors will be recycled or truncated.")
+        if (length(colors) < length(clusterLevels)) {
+            warning("Length of 'cols' (", length(colors), ") is less than number of clusters (", 
+                   length(clusterLevels), "). Colors will be recycled.")
         }
+        # Use first n colors if more are provided, recycle if fewer
         pal <- setNames(rep(colors, length.out = length(clusterLevels)), clusterLevels)
         colors <- pal[maskTable$cluster]
     }

--- a/man/fancyMask.Rd
+++ b/man/fancyMask.Rd
@@ -14,7 +14,8 @@ fancyMask(
   label.fontsize = 10,
   label.buffer = unit(0, "cm"),
   label.fontface = "plain",
-  label.margin = margin(2, 2, 2, 2, "pt")
+  label.margin = margin(2, 2, 2, 2, "pt"),
+  cols = NULL
 )
 }
 \arguments{
@@ -49,6 +50,10 @@ Default is \code{10}.}
 
 \item{label.margin}{Label margin passed to
 \code{geom_mark_shape()}. Default is \code{margin(2, 2, 2, 2, "pt")}.}
+
+\item{cols}{Optional vector of colors for the mask outlines and labels.
+Should have length equal to the number of unique clusters in \code{maskTable}.
+If \code{NULL} (default), colors are generated automatically using \code{scales::hue_pal()}.}
 }
 \value{
 A list of ggplot2 components suitable for adding to a plot with \code{+},


### PR DESCRIPTION
```R
pbmc3k <- readRDS(url("https://alserglab.wustl.edu/files/mascarade/examples/pbmc3k_seurat5.rds"))

maskTable <- generateMaskSeurat(pbmc3k)

DimPlot(pbmc3k) + NoLegend() +
  ggthemes::scale_color_tableau() +
  fancyMask(maskTable, ratio=1, cols = ggthemes::tableau_color_pal()(10))
```

<img width="1234" height="936" alt="image" src="https://github.com/user-attachments/assets/fce14bab-abab-4233-91f9-001878be03c9" />
